### PR TITLE
Fix path in docs for websocket server

### DIFF
--- a/docs-src/replication-websocket.md
+++ b/docs-src/replication-websocket.md
@@ -21,7 +21,7 @@ const myDatabase = await createRxDatabase({/* ... */});
 const serverState = await startWebsocketServer({
     database: myDatabase,
     port: 1337,
-    path: 'socket'
+    path: '/socket'
 });
 
 // stop the server


### PR DESCRIPTION
## This PR contains:

 - IMPROVED DOCS

## Describe the problem you have without this PR

I tried to use the WebSocket replication server with the code from the documentation. In my tests, the call to `replicateWithWebsocketServer` never completed. Adding a leading `/` to the path on the server seems to solve the issue.